### PR TITLE
Add ordered keyframe points only

### DIFF
--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -309,8 +309,12 @@ class PropertiesModel(updates.UpdateInterface):
                         # Keyframe
                         # Loop through points, find a matching points on this frame
                         found_point = False
+                        last_point_idx = 0
                         for point in c.data[property_key][color]["Points"]:
                             log.info("looping points: co.X = %s" % point["co"]["X"])
+                            if point["co"]["X"] < self.frame_number:
+                                # Remember index(+1) of the point previous to the current frame
+                                last_point_idx += 1
                             if interpolation == -1 and point["co"]["X"] == self.frame_number:
                                 # Found point, Update value
                                 found_point = True
@@ -350,7 +354,7 @@ class PropertiesModel(updates.UpdateInterface):
                         if not found_point:
                             clip_updated = True
                             log.info("Created new point at X=%s" % self.frame_number)
-                            c.data[property_key][color]["Points"].append({'co': {'X': self.frame_number, 'Y': new_value}, 'interpolation': 1})
+                            c.data[property_key][color]["Points"].insert(last_point_idx, {'co': {'X': self.frame_number, 'Y': new_value}, 'interpolation': 1})
 
                 # Reduce # of clip properties we are saving (performance boost)
                 c.data = {property_key: c.data[property_key]}
@@ -436,8 +440,12 @@ class PropertiesModel(updates.UpdateInterface):
                     # Loop through points, find a matching points on this frame
                     found_point = False
                     point_to_delete = None
+                    last_point_idx = 0
                     for point in c.data[property_key]["Points"]:
                         log.info("looping points: co.X = %s" % point["co"]["X"])
+                        if point["co"]["X"] < self.frame_number:
+                            # Remember index(+1) of the point previous to the current frame
+                            last_point_idx += 1
                         if interpolation == -1 and point["co"]["X"] == self.frame_number:
                             # Found point, Update value
                             found_point = True
@@ -486,7 +494,7 @@ class PropertiesModel(updates.UpdateInterface):
                     elif not found_point and new_value != None:
                         clip_updated = True
                         log.info("Created new point at X=%s" % self.frame_number)
-                        c.data[property_key]["Points"].append({'co': {'X': self.frame_number, 'Y': new_value}, 'interpolation': 1})
+                        c.data[property_key]["Points"].insert(last_point_idx, {'co': {'X': self.frame_number, 'Y': new_value}, 'interpolation': 1})
 
             if not clip_updated:
                 # If no keyframe was found, set a basic property


### PR DESCRIPTION
When adding new keyframe point, make sure that it will be inserted to
the right place in the dictionary (ordered by constantly increasing
frames).