### PR TITLE
Fix the updating of the type of previous point

### DIFF
--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -324,13 +324,12 @@ class PropertiesModel(updates.UpdateInterface):
                                 # Only update interpolation type (and the LEFT side of the curve)
                                 found_point = True
                                 clip_updated = True
-                                point["interpolation"] = interpolation
                                 if interpolation == 0:
                                     point["handle_right"] = point.get("handle_right") or {"Y": 0.0, "X": 0.0}
                                     point["handle_right"]["X"] = interpolation_details[0]
                                     point["handle_right"]["Y"] = interpolation_details[1]
 
-                                log.info("updating interpolation mode point: co.X = %s to %s" % (point["co"]["X"], interpolation))
+                                log.info("updating interpolation preset of the point: co.X = %s" % (point["co"]["X"]))
                                 log.info("use interpolation preset: %s" % str(interpolation_details))
 
                             elif interpolation > -1 and point["co"]["X"] == closest_point_x:
@@ -454,13 +453,12 @@ class PropertiesModel(updates.UpdateInterface):
                             # Only update interpolation type (and the LEFT side of the curve)
                             found_point = True
                             clip_updated = True
-                            point["interpolation"] = interpolation
                             if interpolation == 0:
                                 point["handle_right"] = point.get("handle_right") or {"Y": 0.0, "X": 0.0}
                                 point["handle_right"]["X"] = interpolation_details[0]
                                 point["handle_right"]["Y"] = interpolation_details[1]
 
-                            log.info("updating interpolation mode point: co.X = %s to %s" % (point["co"]["X"], interpolation))
+                            log.info("updating interpolation preset of the point: co.X = %s" % (point["co"]["X"]))
                             log.info("use interpolation preset: %s" % str(interpolation_details))
 
                         elif interpolation > -1 and point["co"]["X"] == closest_point_x:


### PR DESCRIPTION
The interpolation type of the previous point shouldn't be changed when
interpolation coefficients added.

This fixes issue when current and previous segment both modifies its
interpolation type, when only current was modified.

In libopenshot the closest_point_x is defines interpolation for the
segment, while previous_point_x only stores interpolation coefficients
(details) that may be needed to calculate the value for the
closest_point_x segment of the curve.

Co-authored-by: Stephane Chauveau <schauveau@users.noreply.github.com>