### PR TITLE
Fix background color of the Preview widget

### DIFF
--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -81,7 +81,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         painter.setRenderHints(QPainter.Antialiasing | QPainter.SmoothPixmapTransform | QPainter.TextAntialiasing, True)
 
         # Fill the whole widget with the solid color
-        painter.fillRect(event.rect(), QColor("#191919"))
+        painter.fillRect(event.rect(), self.palette().window())
 
         # Find centered viewport
         viewport_rect = self.centeredViewport(self.width(), self.height())


### PR DESCRIPTION
The video rendering area is usually smaller than the widget size.
The widget itself occupies whole Preview window and for bright UI
themes it should be painted into the window color first.